### PR TITLE
Bottom Margins should not be set by Input Components

### DIFF
--- a/src/components/styles/Date.styles.ts
+++ b/src/components/styles/Date.styles.ts
@@ -5,6 +5,4 @@ export const dateClass = css({
   width: "100%"
 });
 
-export const dropDownClassName = css({
-  marginTop: -40
-});
+export const dropDownClassName = css({});

--- a/src/components/styles/Dropdown.styles.ts
+++ b/src/components/styles/Dropdown.styles.ts
@@ -8,6 +8,5 @@ export const dropDownStyle = css({
   borderRadius: constants.borderRadius,
   position: "absolute",
   zIndex: 999,
-  marginTop: 10,
   transformOrigin: "top left"
 });

--- a/src/components/styles/Input.styles.ts
+++ b/src/components/styles/Input.styles.ts
@@ -10,8 +10,6 @@ export const wrapperStyle = css({
   backgroundColor: colors.white.base,
   width: "100%",
   flexDirection: "column",
-  marginBottom: 20,
-  height: 68,
   "&._pebble_input_wrapper_textarea": {
     height: 110
   }

--- a/src/components/styles/Select.styles.ts
+++ b/src/components/styles/Select.styles.ts
@@ -9,9 +9,7 @@ export const selectInputStyle = css({
   pointerEvents: "none"
 });
 
-export const dropDownClass = css({
-  marginTop: -40
-});
+export const dropDownClass = css({});
 
 export const inputWrapper = css({
   cursor: "pointer",

--- a/src/components/styles/TypeAhead.styles.ts
+++ b/src/components/styles/TypeAhead.styles.ts
@@ -8,7 +8,6 @@ export const wrapper = css({
 export const optionsWrapper = css({
   width: "100%",
   position: "absolute",
-  marginTop: -40,
   zIndex: 999,
   boxShadow: constants.boxShadow.elevated
 });


### PR DESCRIPTION
Need to place TypeAhead in Header where margin-bottom should not be there.

This might be a personal choice, this will need changes in a lot of places or should I write a hack to remove margin-bottom for the Input that I am placing in the header.

Negative margins feel wrong so I think this is how we should go about this.

See the components with Grey Background to see the effect