### PR TITLE
Change React.ReactChildren | React.ReactChild to JSX.Element

### DIFF
--- a/src/components/typings/Popper.ts
+++ b/src/components/typings/Popper.ts
@@ -12,7 +12,7 @@ export interface PopperProps extends Partial<PopperProps_> {
   popperBackgroundColor?: string;
   children: (
     args: { toggle: () => void; isOpen: boolean }
-  ) => React.ReactChildren | React.ReactChild;
+  ) => JSX.Element;
   isOpen?: boolean;
   controlled?: boolean;
   popperClassName?: string;


### PR DESCRIPTION
Both are used interchangeably. Will be changing across repo to check for edge cases.