### PR TITLE
update react-calendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "just-debounce-it": "^1.1.0",
     "mitt": "^1.1.3",
     "react": "^16.5.2",
-    "react-calendar": "^2.17.4",
+    "react-calendar": "^2.17.5",
     "react-dom": "^16.5.2",
     "react-ink": "^6.4.0",
     "react-popper": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9925,10 +9925,10 @@ react-base16-styling@^0.6.0:
     lodash.flow "^3.3.0"
     pure-color "^1.2.0"
 
-react-calendar@^2.17.4:
-  version "2.17.4"
-  resolved "https://registry.yarnpkg.com/react-calendar/-/react-calendar-2.17.4.tgz#95aeb1545159b97727f152f091ef563624dfd70c"
-  integrity sha512-rNpq5R6awa3Krb8rcgBsD6/KkGKvAUGL/jcBvO9f3ikzrRAsBPwQrsu7stiahup0khFfAPRNT5DKaMMNS2bAgQ==
+react-calendar@^2.17.5:
+  version "2.17.5"
+  resolved "https://registry.yarnpkg.com/react-calendar/-/react-calendar-2.17.5.tgz#eba17a5614c27b70caa635ce74a1471b033f4890"
+  integrity sha512-8QeCsZUoe+X0NjNVMx6kZQyPSV8ttnRyqXV72Dxp16t6wGyOFBHMLmsHJVcdlxlIUFKp6LfHrCRZ9IWp6RrZBw==
   dependencies:
     get-user-locale "^1.1.1"
     merge-class-names "^1.1.1"


### PR DESCRIPTION
fixes reverse selection of dates. (https://github.com/wojtekmaj/react-calendar/releases/tag/v2.17.5)