### PR TITLE
Remove display flex from Modal

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,10 +1,6 @@
 import * as React from "react";
 import { ModalProps } from "./typings/Modal";
-import {
-  modalContainer,
-  flexCenter,
-  absoluteCenter
-} from "./styles/Modal.styles";
+import { modalContainer } from "./styles/Modal.styles";
 import { cx } from "emotion";
 import isBrowser from "is-in-browser";
 import * as ReactDOM from "react-dom";
@@ -38,7 +34,7 @@ class Modal extends React.PureComponent<ModalProps> {
   render(): React.ReactNode {
     if (!isBrowser) return null;
 
-    const { children, visible, className, align } = this.props;
+    const { children, visible, backDropClassName, modalClassName } = this.props;
     const node = this.node;
 
     return ReactDOM.createPortal(
@@ -48,13 +44,10 @@ class Modal extends React.PureComponent<ModalProps> {
             style={{
               opacity: transitionStyles.opacity
             }}
-            className={cx(modalContainer, className)}
+            className={cx(modalContainer, backDropClassName)}
           >
             <div
-              className={cx({
-                [absoluteCenter]: align === "absoluteCenter",
-                [flexCenter]: align === "flexCenter"
-              })}
+              className={modalClassName}
               style={{ transform: transitionStyles.transform }}
             >
               {children}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,6 +1,10 @@
 import * as React from "react";
 import { ModalProps } from "./typings/Modal";
-import { modalContainer } from "./styles/Modal.styles";
+import {
+  modalContainer,
+  flexCenter,
+  absoluteCenter
+} from "./styles/Modal.styles";
 import { cx } from "emotion";
 import isBrowser from "is-in-browser";
 import * as ReactDOM from "react-dom";
@@ -34,7 +38,7 @@ class Modal extends React.PureComponent<ModalProps> {
   render(): React.ReactNode {
     if (!isBrowser) return null;
 
-    const { children, visible, className } = this.props;
+    const { children, visible, className, align } = this.props;
     const node = this.node;
 
     return ReactDOM.createPortal(
@@ -47,7 +51,11 @@ class Modal extends React.PureComponent<ModalProps> {
             className={cx(modalContainer, className)}
           >
             <div
-              style={{ transform: transitionStyles.transform, display: "flex" }}
+              className={cx({
+                [absoluteCenter]: align === "absoluteCenter",
+                [flexCenter]: align === "flexCenter"
+              })}
+              style={{ transform: transitionStyles.transform }}
             >
               {children}
             </div>

--- a/src/components/PopUp.tsx
+++ b/src/components/PopUp.tsx
@@ -20,7 +20,7 @@ const PopUp: React.FunctionComponent<PopUpProps> = props => {
     children
   } = props;
   return (
-    <Modal visible={visible}>
+    <Modal visible={visible} align="flexCenter">
       <div className={modalContainer}>
         {onClose && (
           <i

--- a/src/components/PopUp.tsx
+++ b/src/components/PopUp.tsx
@@ -5,7 +5,8 @@ import Button from "./Button";
 import {
   modalContainer,
   buttonsContainer,
-  iconCloseClassName
+  iconCloseClassName,
+  flexCenter
 } from "./styles/PopUp.styles";
 import { PopUpProps } from "./typings/PopUp";
 
@@ -20,7 +21,7 @@ const PopUp: React.FunctionComponent<PopUpProps> = props => {
     children
   } = props;
   return (
-    <Modal visible={visible} align="flexCenter">
+    <Modal visible={visible} modalClassName={flexCenter}>
       <div className={modalContainer}>
         {onClose && (
           <i

--- a/src/components/styles/Modal.styles.ts
+++ b/src/components/styles/Modal.styles.ts
@@ -13,16 +13,3 @@ export const modalContainer = css({
   WebkitOverflowScrolling: "touch",
   zIndex: 99998
 });
-
-export const absoluteCenter = css({
-  position: "absolute",
-  top: "50%",
-  left: "50%",
-  margin: "auto",
-  transform: "translate(-50%, -50%)"
-});
-
-export const flexCenter = css({
-  display: "flex",
-  alignItems: "center"
-});

--- a/src/components/styles/Modal.styles.ts
+++ b/src/components/styles/Modal.styles.ts
@@ -13,3 +13,16 @@ export const modalContainer = css({
   WebkitOverflowScrolling: "touch",
   zIndex: 99998
 });
+
+export const absoluteCenter = css({
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  margin: "auto",
+  transform: "translate(-50%, -50%)"
+});
+
+export const flexCenter = css({
+  display: "flex",
+  alignItems: "center"
+});

--- a/src/components/styles/PopUp.styles.ts
+++ b/src/components/styles/PopUp.styles.ts
@@ -12,6 +12,11 @@ export const modalContainer = css({
   position: "relative"
 });
 
+export const flexCenter = css({
+  display: "flex",
+  alignItems: "center"
+});
+
 export const buttonsContainer = css({
   ...mixins.flexSpaceBetween,
   marginTop: "40px"

--- a/src/components/typings/Modal.ts
+++ b/src/components/typings/Modal.ts
@@ -1,6 +1,6 @@
 export interface ModalProps {
   visible: boolean;
-  className?: string;
+  backDropClassName?: string;
+  modalClassName?: string;
   children: React.ReactNode;
-  align?: "absoluteCenter" | "flexCenter";
 }

--- a/src/components/typings/Modal.ts
+++ b/src/components/typings/Modal.ts
@@ -2,4 +2,5 @@ export interface ModalProps {
   visible: boolean;
   className?: string;
   children: React.ReactNode;
+  align?: "absoluteCenter" | "flexCenter";
 }


### PR DESCRIPTION
Switched to two classnames which are easier to understand what they are associated with.
And because both prop names have been changed, typescript will tell us where we need to double check how the modal looks.