### PR TITLE
Fix Mobile Input

### DIFF
--- a/src/components/DateInput.tsx
+++ b/src/components/DateInput.tsx
@@ -5,8 +5,8 @@ import { dateClass, dropDownClassName } from "./styles/Date.styles";
 import { format } from "date-fns";
 import Calendar from "./Calendar";
 import Input from "./Input";
-import { cx, css } from "emotion";
-import { isDesktop } from "../utils";
+// import { cx, css } from "emotion";
+// import { isDesktop } from "../utils";
 
 class DateInput extends React.PureComponent<DateInputProps> {
   onChange = (date: Date | string) => {
@@ -16,15 +16,16 @@ class DateInput extends React.PureComponent<DateInputProps> {
   render() {
     const { value, calendarProps } = this.props;
 
-    const dropDownClass = cx(dropDownClassName, {
-      [css({
-        display: "none"
-      })]: !isDesktop
-    });
+    // const dropDownClass = cx(dropDownClassName, {
+    //   [css({
+    //     display: "none"
+    //   })]: !isDesktop
+    // });
 
     return (
       <DropDown
-        dropDownClassName={dropDownClass}
+        // dropDownClassName={dropDownClass}
+        dropDownClassName={dropDownClassName}
         labelComponent={({ toggleDropdown }) => (
           <Input
             onChange={this.onChange}

--- a/src/components/styles/Input.styles.ts
+++ b/src/components/styles/Input.styles.ts
@@ -1,6 +1,6 @@
 import { colors, mixins, typography } from "../../theme";
 import { css } from "emotion";
-import { isDesktop } from "../../utils";
+// import { isDesktop } from "../../utils";
 
 const animation = "all 0.3s cubic-bezier(.64,.09,.08,1)";
 
@@ -32,13 +32,15 @@ export const inputStyle = css({
   "&:disabled": {
     backgroundColor: colors.white.base
   },
-  "&[type='date']": {
-    ...(!isDesktop ? { "-webkit-appearance": "textfield" } : {})
-  },
-  "&[type='date']::-webkit-inner-spin-button, &[type='date']::-webkit-calendar-picker-indicator": {
-    webkitAppearance: "none",
-    display: "none"
-  },
+  // ...(isDesktop && {
+  //   "&[type='date']": {
+  //     "-webkit-appearance": "textfield"
+  //   },
+  //   "&[type='date']::-webkit-inner-spin-button, &[type='date']::-webkit-calendar-picker-indicator": {
+  //     webkitAppearance: "none",
+  //     display: "none"
+  //   },
+  // }),
   .../*#__PURE__*/ mixins.getPlaceholderStyle(colors.gray.light)
 });
 

--- a/src/utils/dimensions.ts
+++ b/src/utils/dimensions.ts
@@ -4,4 +4,4 @@ function width() {
   return (isBrowser && window.screen.width) || 1025;
 }
 
-export const isDesktop = /*@__PURE__*/ width() > 1024;
+export const isDesktop = /*@__PURE__*/ width() >= 1024;


### PR DESCRIPTION
The DateInput it seems was meant to show the system selector on mobile but its implementation was broken.
Need to urgently fix this for Call Center.

Currently setting date in the input throws this error:
"The specified value "10/01/2019" does not conform to the required format, "yyyy-MM-dd"."

So maybe we might need to create a dummy date input/placeholder to show date in our locale: "DD-MM-YYYY"
